### PR TITLE
DeathLink -> death_link

### DIFF
--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -500,8 +500,11 @@ bool parse_response(std::string msg, std::string &request) {
             for (unsigned int j = 0; j < root[i]["players"].size(); j++) {
                 map_player_id_alias.insert(std::pair<int,std::string>(root[i]["players"][j]["slot"].asInt(),root[i]["players"][j]["alias"].asString()));
             }
-            if (root[i]["slot_data"].get("DeathLink", false).asBool() && deathlinksupported) enable_deathlink = true;
-            deathlink_amnesty = root[i]["slot_data"].get("DeathLink_Amnesty", 0).asInt();
+            if ((root[i]["slot_data"].get("death_link", false).asBool() || root[i]["slot_data"].get("DeathLink", false).asBool()) && deathlinksupported) enable_deathlink = true;
+            if (root[i]["slot_data"]["death_link_amnesty"] != Json::nullValue)
+                deathlink_amnesty = root[i]["slot_data"].get("death_link_amnesty", 0).asInt();
+            else if (root[i]["slot_data"]["DeathLink_Amnesty"] != Json::nullValue)
+                deathlink_amnesty = root[i]["slot_data"].get("DeathLink_Amnesty", 0).asInt();
             cur_deathlink_amnesty = deathlink_amnesty;
             for (std::string key : slotdata_strings) {
                 if (map_slotdata_callback_int.count(key)) {


### PR DESCRIPTION
AP devs confirmed that the correct way to write it in the slot data is `death_link`. I am trying to clean up my "local hacks". So creating this PR to make the change official in APcpp.

Keeping `DeathLink` in the code for backward compatibility with games that are already be using APcpp