### PR TITLE
Added AP_GetPlayerId

### DIFF
--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -406,6 +406,10 @@ int AP_GetUUID() {
     return ap_uuid;
 }
 
+int AP_GetPlayerID() {
+    return ap_player_id;
+}
+
 void AP_SetServerData(AP_SetServerDataRequest* request) {
     request->status = AP_RequestStatus::Pending;
 

--- a/Archipelago.h
+++ b/Archipelago.h
@@ -150,6 +150,7 @@ struct AP_RoomInfo {
 int AP_GetRoomInfo(AP_RoomInfo*);
 AP_ConnectionStatus AP_GetConnectionStatus();
 int AP_GetUUID();
+int AP_GetPlayerID();
 
 /* Serverside Data Types */
 


### PR DESCRIPTION
Convenient to have. In Faxanadu I am using this to compare if the Item received is from my world or not. In Doom I didn't care about this, that's why it didn't come up earlier.