### PR TITLE
Limit connection retries

### DIFF
--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -20,6 +20,7 @@
 
 #define AP_OFFLINE_SLOT 1404
 #define AP_OFFLINE_NAME "You"
+#define AP_RETRY_COUNT 5
 
 //Setup Stuff
 bool init = false;
@@ -147,11 +148,18 @@ void AP_Init(const char* ip, const char* game, const char* player_name, const ch
                     itr.second->status = AP_RequestStatus::Error;
                     map_server_data.erase(itr.first);
                 }
-                printf("AP: Error connecting to Archipelago. Retries: %d\n", msg->errorInfo.retries-1);
-                if (msg->errorInfo.retries-1 >= 2 && isSSL && !ssl_success) {
-                    printf("AP: SSL connection failed. Attempting unencrypted...\n");
-                    webSocket.setUrl("ws://" + ap_ip);
-                    isSSL = false;
+                if (msg->errorInfo.retries >= AP_RETRY_COUNT)
+                {
+                    refused = true;
+                }
+                else
+                {
+                    printf("AP: Error connecting to Archipelago. Retries: %d\n", msg->errorInfo.retries-1);
+                    if (msg->errorInfo.retries-1 >= 2 && isSSL && !ssl_success) {
+                        printf("AP: SSL connection failed. Attempting unencrypted...\n");
+                        webSocket.setUrl("ws://" + ap_ip);
+                        isSSL = false;
+                    }
                 }
             }
         }


### PR DESCRIPTION
It's pointless to keep retrying forever. The game is waiting for a success or failure callback and the failure never comes. I am showing a popup in game and give the chance to the user to change the address and retry again