### PR TITLE
Fixed bug with location information

### DIFF
--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -740,7 +740,7 @@ bool parse_response(std::string msg, std::string &request) {
                 item.player = player.slot;
                 item.flags = root[i]["locations"][j]["flags"].asInt();
                 item.itemName = getItemName(player.game, item.item);
-                item.locationName = getLocationName(player.game, item.location);
+                item.locationName = getLocationName(ap_game, item.location);
                 item.playerName = player.alias;
                 locations.push_back(item);
             }


### PR DESCRIPTION
the player in an AP_NetworkItem is always the player of the containing world, EXCEPT in LocationInformation than its the player who will receive the item, as scouts are always your own locations, we should use our local game for that