### PR TITLE
Fixed issue where the default client version got set when AP_Shutdown() gets called

### DIFF
--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -22,6 +22,7 @@
 
 constexpr int AP_OFFLINE_SLOT = 1404;
 #define AP_OFFLINE_NAME "You"
+constexpr AP_DEFAULT_NETWORK_VERSION = {0,5,1}; // Default for compatibility reasons
 
 //Setup Stuff
 bool init = false;
@@ -38,7 +39,7 @@ std::string ap_game;
 std::string ap_passwd;
 std::uint64_t ap_uuid = 0;
 std::mt19937 rando;
-AP_NetworkVersion client_version = {0,5,1}; // Default for compatibility reasons
+AP_NetworkVersion client_version = AP_DEFAULT_NETWORK_VERSION; 
 
 //Deathlink Stuff
 bool deathlinkstat = false;
@@ -249,7 +250,7 @@ void AP_Shutdown() {
     ap_game.clear();
     ap_passwd.clear();
     ap_uuid = 0;
-    client_version = {0,2,6};
+    client_version = AP_DEFAULT_NETWORK_VERSION;
     deathlinkstat = false;
     deathlinksupported = false;
     enable_deathlink = false;

--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -21,7 +21,7 @@
 #include <vector>
 
 constexpr int AP_OFFLINE_SLOT = 1404;
-#define AP_OFFLINE_NAME "You"
+constexpr char const* AP_OFFLINE_NAME = "You";
 constexpr AP_DEFAULT_NETWORK_VERSION = {0,5,1}; // Default for compatibility reasons
 
 //Setup Stuff


### PR DESCRIPTION
Added a constexpr for the default clientversion so it only needs to be changed in one location if required in the future.
Changed AP_OFFLINE_NAME to a constexpr, not a necessary change but it keeps it in line with the rest of the definitions