### PR TITLE
Only set Auth after downloading all data packages

### DIFF
--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -664,9 +664,6 @@ bool parse_response(std::string msg, std::string &request) {
             printf("AP: Authenticated\n");
             ap_player_id = root[i]["slot"].asInt(); // MUST be called before resetitemvalues, otherwise PrivateServerDataPrefix, GetPlayerID return broken values!
             (*resetItemValues)();
-            auth = true;
-            ssl_success = auth && isSSL;
-            refused = false;
 
             for (unsigned int j = 0; j < root[i]["checked_locations"].size(); j++) {
                 //Sync checks with server
@@ -693,7 +690,7 @@ bool parse_response(std::string msg, std::string &request) {
             for (std::string key : slotdata_strings) {
                 if (map_slotdata_callback_int.count(key)) {
                     (*map_slotdata_callback_int.at(key))(root[i]["slot_data"][key].asInt());
-                    } else if (map_slotdata_callback_raw.count(key)) {
+                } else if (map_slotdata_callback_raw.count(key)) {
                     (*map_slotdata_callback_raw.at(key))(writer.write(root[i]["slot_data"][key]));
                 } else if (map_slotdata_callback_mapintint.count(key)) {
                     std::map<int,int> out;
@@ -702,7 +699,6 @@ bool parse_response(std::string msg, std::string &request) {
                     }
                     (*map_slotdata_callback_mapintint.at(key))(out);
                 }
-                
             }
 
             resync_serverdata_request.key = "APCppLastRecv" + ap_player_name + std::to_string(ap_player_id);
@@ -737,6 +733,10 @@ bool parse_response(std::string msg, std::string &request) {
                 Json::Value sync;
                 sync["cmd"] = "Sync";
                 req_t.append(sync);
+
+                auth = true;
+                ssl_success = auth && isSSL;
+                refused = false;
             }
             request = writer.write(req_t);
             return true;
@@ -975,6 +975,12 @@ void parseDataPkg(Json::Value new_datapkg) {
     }
     WriteFileJSON(datapkg_cache, datapkg_cache_path);
     parseDataPkg();
+
+    if (datapkg_outdated_games.empty()){
+        auth = true;
+        ssl_success = auth && isSSL;
+        refused = false;
+    }
 }
 
 void parseDataPkg() {

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The secound parameter decides whether or not to notify the player
 - `AP_SetLocationCheckedCallback(void (*f_locrecv)(int))` with a callback that marks the location with the given id (first parameter) as checked.
 
 Optionally, for finer configuration:
-- AP_EnableQueueItemRecvMsgs(bool)` Enables or disables Item Messages for Items received for the current game. Alternative to using the game's native item reception handler, if present. Defaults to on.
+- `AP_EnableQueueItemRecvMsgs(bool)` Enables or disables Item Messages for Items received for the current game. Alternative to using the game's native item reception handler, if present. Defaults to on.
 
 Optionally, for DeathLink:
 - `AP_SetDeathLinkSupported(bool)` Enables or disables DeathLink from the Library. Defaults to off. NOTE: If on, expects DeathLink data from Archipelago.


### PR DESCRIPTION
Fix for Satisfactory retreiving item names before all packages have downloaded and thus getting unknown items
![image](https://github.com/user-attachments/assets/aa5ebddc-f345-4327-a398-c885ddf54321)
