### PR TITLE
Enable websocket compression

### DIFF
--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -161,6 +161,7 @@ void AP_Init(const char* ip, const char* game, const char* player_name, const ch
             }
         }
     );
+    webSocket.enablePerMessageDeflate();
     webSocket.setPingInterval(45);
 
     AP_NetworkPlayer archipelago {


### PR DESCRIPTION
IXWebSocket is not actually enabling websocket compression by default despite its documentation, so add an explicit call to enable it.

Reported the bug upstream: https://github.com/machinezone/IXWebSocket/issues/547