### PR TITLE
Added more DataTypes for DataStorage

### DIFF
--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -925,7 +925,19 @@ bool parse_response(std::string msg, std::string &request) {
                         setreply.value = &int_val;
                         setreply.original_value = &int_orig_val;
                         break;
-                    case AP_DataType::Double:
+                    case AP_DataType::Int64:
+                        int_val = root[i]["value"].asInt64();
+                        int_orig_val = root[i]["original_value"].asInt64();
+                        setreply.value = &int_val;
+                        setreply.original_value = &int_orig_val;
+                        break;
+                    case AP_DataType::UnsignedInt64:
+                        int_val = root[i]["value"].asUInt64();
+                        int_orig_val = root[i]["original_value"].asUInt64();
+                        setreply.value = &int_val;
+                        setreply.original_value = &int_orig_val;
+                        break;
+                   case AP_DataType::Double:
                         dbl_val = root[i]["value"].asDouble();
                         dbl_orig_val = root[i]["original_value"].asDouble();
                         setreply.value = &dbl_val;

--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -547,15 +547,6 @@ void AP_BulkSetServerData(AP_SetServerDataRequest* request) {
                 req_t["default"] = *((int64_t*)request->default_value);
             }
             break;
-        case AP_DataType::UnsignedInt64:
-            for (int i = 0; i < request->operations.size(); i++) {
-                req_t["operations"][i]["operation"] = request->operations[i].operation;
-                req_t["operations"][i]["value"] = *((uint64_t*)request->operations[i].value);
-            }
-            if (request->default_value != nullptr) {
-                req_t["default"] = *((uint64_t*)request->default_value);
-            }
-            break;
         case AP_DataType::Double:
             for (int i = 0; i < request->operations.size(); i++) {
                 req_t["operations"][i]["operation"] = request->operations[i].operation;
@@ -633,7 +624,6 @@ void AP_SetNotify(std::map<std::string,AP_DataType> keylist, bool requestCurrent
             switch (keytypepair.second) {
                 case AP_DataType::Int:
                 case AP_DataType::Int64:
-                case AP_DataType::UnsignedInt64:
                 case AP_DataType::Double:
                     setDefaultRequest.operations = {{"default", &zero}};
                     setDefaultRequest.default_value = &zero;
@@ -883,9 +873,6 @@ bool parse_response(std::string msg, std::string &request) {
                     case AP_DataType::Int64:
                         *((int64_t*)target->value) = root[i]["keys"][itr].asInt64();
                         break;
-                    case AP_DataType::UnsignedInt64:
-                        *((uint64_t*)target->value) = root[i]["keys"][itr].asUInt64();
-                        break;
                     case AP_DataType::Double:
                         *((double*)target->value) = root[i]["keys"][itr].asDouble();
                         break;
@@ -928,12 +915,6 @@ bool parse_response(std::string msg, std::string &request) {
                     case AP_DataType::Int64:
                         int_val = root[i]["value"].asInt64();
                         int_orig_val = root[i]["original_value"].asInt64();
-                        setreply.value = &int_val;
-                        setreply.original_value = &int_orig_val;
-                        break;
-                    case AP_DataType::UnsignedInt64:
-                        int_val = root[i]["value"].asUInt64();
-                        int_orig_val = root[i]["original_value"].asUInt64();
                         setreply.value = &int_val;
                         setreply.original_value = &int_orig_val;
                         break;

--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -538,6 +538,24 @@ void AP_BulkSetServerData(AP_SetServerDataRequest* request) {
                 req_t["default"] = *((int*)request->default_value);
             }
             break;
+        case AP_DataType::Int64:
+            for (int i = 0; i < request->operations.size(); i++) {
+                req_t["operations"][i]["operation"] = request->operations[i].operation;
+                req_t["operations"][i]["value"] = *((int64_t*)request->operations[i].value);
+            }
+            if (request->default_value != nullptr) {
+                req_t["default"] = *((int64_t*)request->default_value);
+            }
+            break;
+        case AP_DataType::UnsignedInt64:
+            for (int i = 0; i < request->operations.size(); i++) {
+                req_t["operations"][i]["operation"] = request->operations[i].operation;
+                req_t["operations"][i]["value"] = *((uint64_t*)request->operations[i].value);
+            }
+            if (request->default_value != nullptr) {
+                req_t["default"] = *((uint64_t*)request->default_value);
+            }
+            break;
         case AP_DataType::Double:
             for (int i = 0; i < request->operations.size(); i++) {
                 req_t["operations"][i]["operation"] = request->operations[i].operation;
@@ -614,6 +632,8 @@ void AP_SetNotify(std::map<std::string,AP_DataType> keylist, bool requestCurrent
             setDefaultRequest.want_reply = true;
             switch (keytypepair.second) {
                 case AP_DataType::Int:
+                case AP_DataType::Int64:
+                case AP_DataType::UnsignedInt64:
                 case AP_DataType::Double:
                     setDefaultRequest.operations = {{"default", &zero}};
                     setDefaultRequest.default_value = &zero;
@@ -859,6 +879,12 @@ bool parse_response(std::string msg, std::string &request) {
                 switch (target->type) {
                     case AP_DataType::Int:
                         *((int*)target->value) = root[i]["keys"][itr].asInt();
+                        break;
+                    case AP_DataType::Int64:
+                        *((int*)target->value) = root[i]["keys"][itr].asInt64();
+                        break;
+                    case AP_DataType::UnsignedInt64:
+                        *((int*)target->value) = root[i]["keys"][itr].asUInt64();
                         break;
                     case AP_DataType::Double:
                         *((double*)target->value) = root[i]["keys"][itr].asDouble();

--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -899,6 +899,8 @@ bool parse_response(std::string msg, std::string &request) {
             if (setreplyfunc) {
                 int int_val;
                 int int_orig_val;
+                int64_t int64_val;
+                int64_t int64_orig_val;
                 double dbl_val;
                 double dbl_orig_val;
                 std::string raw_val;
@@ -913,10 +915,10 @@ bool parse_response(std::string msg, std::string &request) {
                         setreply.original_value = &int_orig_val;
                         break;
                     case AP_DataType::Int64:
-                        int_val = root[i]["value"].asInt64();
-                        int_orig_val = root[i]["original_value"].asInt64();
-                        setreply.value = &int_val;
-                        setreply.original_value = &int_orig_val;
+                        int64_val = root[i]["value"].asInt64();
+                        int64_orig_val = root[i]["original_value"].asInt64();
+                        setreply.value = &int64_val;
+                        setreply.original_value = &int64_orig_val;
                         break;
                    case AP_DataType::Double:
                         dbl_val = root[i]["value"].asDouble();

--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -881,10 +881,10 @@ bool parse_response(std::string msg, std::string &request) {
                         *((int*)target->value) = root[i]["keys"][itr].asInt();
                         break;
                     case AP_DataType::Int64:
-                        *((int*)target->value) = root[i]["keys"][itr].asInt64();
+                        *((int64_t*)target->value) = root[i]["keys"][itr].asInt64();
                         break;
                     case AP_DataType::UnsignedInt64:
-                        *((int*)target->value) = root[i]["keys"][itr].asUInt64();
+                        *((uint64_t*)target->value) = root[i]["keys"][itr].asUInt64();
                         break;
                     case AP_DataType::Double:
                         *((double*)target->value) = root[i]["keys"][itr].asDouble();

--- a/Archipelago.h
+++ b/Archipelago.h
@@ -169,7 +169,7 @@ enum struct AP_RequestStatus {
 };
 
 enum struct AP_DataType {
-    Raw, Int, Double
+    Raw, Int, Double, Int64, UnsignedInt64
 };
 
 struct AP_GetServerDataRequest {

--- a/Archipelago.h
+++ b/Archipelago.h
@@ -169,7 +169,7 @@ enum struct AP_RequestStatus {
 };
 
 enum struct AP_DataType {
-    Raw, Int, Double, Int64, UnsignedInt64
+    Raw, Int, Double, Int64
 };
 
 struct AP_GetServerDataRequest {


### PR DESCRIPTION
I needed an uint64, but it felt odd to just add uint64 and not also int64, 

i guess it also feels kinda odd not to add `uint` when we do have `int`, but if someone needs an uint, i guess it will fit in uint64 just like floats fit in the double