### PR TITLE
feat: add target_include_directories instruction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_library(APCpp SHARED Archipelago.cpp Archipelago_DataStorageSim.cpp Archipelago_Gifting.cpp)
+
+# Allows users to use APCpp as a dependency
+target_include_directories(APCpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
 set_target_properties(APCpp PROPERTIES PUBLIC_HEADER Archipelago.h)
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
The goal of this PR is to allow using APCpp as a dependency of another project by automatically making the Archipelago header file accessible to projects that link against APCpp. 

Currently, the archipelago.h is only available in a specific global directory through `set_target_properties(APCpp PROPERTIES PUBLIC_HEADER Archipelago.h)`, but this is not the most practical way to use this project as a dependency. With this change, it's now possible to use APCpp in your project by simply linking against APCpp with `target_link_libraries(${TARGET} PUBLIC APCpp)`

This is especially useful in UE4SS projects where this way of adding include files is already used, making adding dependency to a UE4SS project much easier (see [this example of using the change](https://github.com/Nebulea-dev/Blue-Fire-Archipelago/blob/main/BlueFireArchipelagoMod/CMakeLists.txt))