### PR TITLE
Fix memory leak: mismatched new/delete for messages (missing virtual destructor)

### DIFF
--- a/Archipelago.h
+++ b/Archipelago.h
@@ -97,6 +97,8 @@ enum struct AP_MessageType {
 };
 
 struct AP_Message {
+    virtual ~AP_Message() = default;
+
     AP_MessageType type = AP_MessageType::Plaintext;
     std::string text;
 };


### PR DESCRIPTION
Found while using valgrind. Inherited classes don't get destructed if the base class doesn't have a virtual destructor. So some memory doesn't get freed and leaks.

```
==773095== Mismatched new/delete size value: 40
==773095==    at 0x4D3EDE5: operator delete(void*, unsigned long) (vg_replace_malloc.c:1146)
==773095==    by 0x524294E: AP_ClearLatestMessage() (in /home/ks/Projects/APDoom/build/lib/libAPCpp.so)
==773095==  Address 0xcd9f6a0 is 0 bytes inside a block of size 104 alloc'd
==773095==    at 0x4D3AF75: operator new(unsigned long) (vg_replace_malloc.c:501)
==773095==    by 0x5248CD5: parse_response(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (in /home/ks/Projects/APDoom/build/lib/libAPCpp.so)
```

(Also, you're probably going to need to update your CI workflows, see df3c7b0)