### PR TITLE
Add Chat and ServerChat types to PrintJSON parsing

### DIFF
--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -945,9 +945,8 @@ bool parse_response(std::string msg, std::string &request) {
                 msg->text = msg->player + ": " + msg->message;
                 messageQueue.push_back(msg);
             } else if (printType == "ServerChat") {
-                AP_ChatMessage* msg = new AP_ChatMessage;
+                AP_ServerChatMessage* msg = new AP_ServerChatMessage;
                 msg->type = AP_MessageType::ServerChat;
-                msg->player = "";
                 msg->message = root[i]["message"].asString();
                 msg->text = "[Server]: " + msg->message;
                 messageQueue.push_back(msg);

--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -937,7 +937,7 @@ bool parse_response(std::string msg, std::string &request) {
                 msg->text = root[i]["data"][0]["text"].asString();
                 messageQueue.push_back(msg);
             } else if (printType == "Chat") {
-                AP_NetworkPlayer sender = getPlayer(0, ap_player_id);
+                AP_NetworkPlayer sender = getPlayer(0, root[i]["slot"].asInt());
                 AP_ChatMessage* msg = new AP_ChatMessage;
                 msg->type = AP_MessageType::Chat;
                 msg->player = sender.alias;

--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -944,8 +944,7 @@ bool parse_response(std::string msg, std::string &request) {
                 msg->message = root[i]["message"].asString();
                 msg->text = msg->player + ": " + msg->message;
                 messageQueue.push_back(msg);
-            }
-            else if (printType == "ServerChat") {
+            } else if (printType == "ServerChat") {
                 AP_ChatMessage* msg = new AP_ChatMessage;
                 msg->type = AP_MessageType::ServerChat;
                 msg->player = "";

--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -936,6 +936,22 @@ bool parse_response(std::string msg, std::string &request) {
                 }
                 msg->text = root[i]["data"][0]["text"].asString();
                 messageQueue.push_back(msg);
+            } else if (printType == "Chat") {
+                AP_NetworkPlayer sender = getPlayer(0, ap_player_id);
+                AP_ChatMessage* msg = new AP_ChatMessage;
+                msg->type = AP_MessageType::Chat;
+                msg->player = sender.alias;
+                msg->message = root[i]["message"].asString();
+                msg->text = msg->player + ": " + msg->message;
+                messageQueue.push_back(msg);
+            }
+            else if (printType == "ServerChat") {
+                AP_ChatMessage* msg = new AP_ChatMessage;
+                msg->type = AP_MessageType::ServerChat;
+                msg->player = "";
+                msg->message = root[i]["message"].asString();
+                msg->text = "[Server]: " + msg->message;
+                messageQueue.push_back(msg);
             } else {
                 AP_Message* msg = new AP_Message;
                 msg->text = "";

--- a/Archipelago.h
+++ b/Archipelago.h
@@ -93,7 +93,7 @@ void AP_DeathLinkSend(const std::string &cause = "");
 /* Message Management Types */
 
 enum struct AP_MessageType {
-    Plaintext, ItemSend, ItemRecv, Hint, Countdown
+    Plaintext, ItemSend, ItemRecv, Hint, Countdown, Chat, ServerChat
 };
 
 struct AP_Message {
@@ -123,6 +123,11 @@ struct AP_HintMessage : AP_Message {
 
 struct AP_CountdownMessage : AP_Message {
     int timer;
+};
+
+struct AP_ChatMessage : AP_Message {
+    std::string player;
+    std::string message;
 };
 
 /* Message Management Functions */

--- a/Archipelago.h
+++ b/Archipelago.h
@@ -130,6 +130,10 @@ struct AP_ChatMessage : AP_Message {
     std::string message;
 };
 
+struct AP_ServerChatMessage : AP_Message {
+    std::string message;
+};
+
 /* Message Management Functions */
 
 bool AP_IsMessagePending();


### PR DESCRIPTION
Handles `Chat` and `ServerChat` print types in the parser so that we can distinguish them from other message types