### PR TITLE
Implement AP_SetTags

### DIFF
--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -389,6 +389,19 @@ void AP_SendLocationScouts(std::set<int64_t> const& locations, int create_as_hin
     }
 }
 
+void AP_SetTags(std::vector<std::string> const& tags)
+{
+    lib_room_info.tags = tags;
+    if (!multiworld) return;
+    Json::Value req_t;
+    req_t[0]["cmd"] = "ConnectUpdate";
+    req_t[0]["tags"] = Json::arrayValue;
+    for (std::string tag : tags) {
+        req_t[0]["tags"].append(tag);
+    }
+    APSend(writer.write(req_t));
+}
+
 void AP_StoryComplete() {
     if (!multiworld) return;
     Json::Value req_t;

--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -389,7 +389,7 @@ void AP_SendLocationScouts(std::set<int64_t> const& locations, int create_as_hin
     }
 }
 
-void AP_SetTags(std::vector<std::string> const& tags)
+void AP_UpdateTags(std::vector<std::string> const& tags)
 {
     lib_room_info.tags = tags;
     if (!multiworld) return;

--- a/Archipelago.h
+++ b/Archipelago.h
@@ -172,6 +172,7 @@ int AP_GetRoomInfo(AP_RoomInfo*);
 AP_ConnectionStatus AP_GetConnectionStatus();
 std::uint64_t AP_GetUUID();
 int AP_GetPlayerID();
+void AP_SetTags(std::vector<std::string> const& tags);
 
 /* Serverside Data Types */
 

--- a/Archipelago.h
+++ b/Archipelago.h
@@ -172,7 +172,7 @@ int AP_GetRoomInfo(AP_RoomInfo*);
 AP_ConnectionStatus AP_GetConnectionStatus();
 std::uint64_t AP_GetUUID();
 int AP_GetPlayerID();
-void AP_SetTags(std::vector<std::string> const& tags);
+void AP_UpdateTags(std::vector<std::string> const& tags);
 
 /* Serverside Data Types */
 


### PR DESCRIPTION
Implements a function to update server connection tags.

Many client protocols like DamageLink and RingLink as well as DamageLinkGroups rely on setting tags to receive bounce packets. As it is currently, without modifications the API is limited to protocols directly supported by the APCpp library. The aim of this PR is to add the option to handle these in the actual client code.

For this purpose the function also modifies the local room info tags so code that changes these tags can be aware of which tags are already added and does not override them unintentionally as AP doesn't send a proper response packet to update the local state.

