### PR TITLE
Fix Bounce packets using string for slots

### DIFF
--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -1077,7 +1077,7 @@ bool parse_response(std::string msg, std::string &request) {
                             bounce.targets = &targets; \
                         }
                 ADD_TARGETS(games, asString)
-                ADD_TARGETS(slots, asUInt64)
+                ADD_TARGETS(slots, asInt64)
                 ADD_TARGETS(tags, asString)
                 #undef ADD_TARGETS
 

--- a/Archipelago.cpp
+++ b/Archipelago.cpp
@@ -1066,19 +1066,19 @@ bool parse_response(std::string msg, std::string &request) {
             } else {
                 AP_Bounce bounce;
                 std::vector<std::string> games;
-                std::vector<std::string> slots;
+                std::vector<int64_t> slots;
                 std::vector<std::string> tags;
                 // Add targets to bounce package
-                #define ADD_TARGETS( targets ) \
+                #define ADD_TARGETS( targets, accessor ) \
                         if (root[i].isMember(#targets)) { \
                             for (unsigned int j = 0; j < root[i][#targets].size(); j++) { \
-                                targets.push_back(root[i][#targets][j].asString()); \
+                                targets.push_back(root[i][#targets][j].accessor()); \
                             } \
                             bounce.targets = &targets; \
                         }
-                ADD_TARGETS(games)
-                ADD_TARGETS(slots)
-                ADD_TARGETS(tags)
+                ADD_TARGETS(games, asString)
+                ADD_TARGETS(slots, asUInt64)
+                ADD_TARGETS(tags, asString)
                 #undef ADD_TARGETS
 
                 bounce.data = writer.write(root[i]["data"]);

--- a/Archipelago.h
+++ b/Archipelago.h
@@ -216,7 +216,7 @@ struct AP_SetReply {
 
 struct AP_Bounce {
     std::vector<std::string>* games = nullptr; // Can be nullptr or empty, but must be set to either
-    std::vector<std::string>* slots = nullptr; // Can be nullptr or empty, but must be set to either
+    std::vector<int64_t>* slots = nullptr; // Can be nullptr or empty, but must be set to either
     std::vector<std::string>* tags  = nullptr; // Can be nullptr or empty, but must be set to either
     std::string data; // Valid JSON Data. Can also be primitive (Numbers or literals)
 };


### PR DESCRIPTION
The APCpp library uses std::string for AP_Bounce.slots, however the documentation for Bounce packets requires slots to be sent as ints. As a result of this error, my MapUpdate packet was not received by poptracker, breaking auto changing tabs there.